### PR TITLE
long away message fix

### DIFF
--- a/include/adminlist.php
+++ b/include/adminlist.php
@@ -66,12 +66,17 @@ function getAdminList() {
                     $offlineClients[] = '<p><span class="label label-primary iconspacer">' . htmlspecialchars($userInfo['client_nickname']) . '</span><span class="label label-danger pull-right">' . translate($lang["adminlist"]["status"]["offline"]) . '</span></p>';
                     continue;
                 }
+                $userAwaya = '';
                 if(!$user["client_away_message"]) {
                     $userAway = translate($lang["adminlist"]["status"]["away"]);
                 }else{
                     $userAway = htmlspecialchars($user["client_away_message"]);
+                    if (strlen($userAway) > 23) {
+                        $userAwaya = 'title="' . $userAway . '"';
+                        $userAway = substr($userAway, 0, 23) . '..';
+                    }
                 }
-                $onlineClients[] = '<p><img src="lib/ts3phpframework/images/viewer/' . $user->getIcon() . '.png" alt="User status">' . '<span class="label label-primary">' . htmlspecialchars($user) . '</span>' . ($user['client_away'] ? '<span class="label label-warning pull-right">' . $userAway . '</span>' : '<span class="label label-success pull-right">' . translate($lang["adminlist"]["status"]["online"]) . '</span>') . '</p>';
+                $onlineClients[] = '<p><img src="lib/ts3phpframework/images/viewer/' . $user->getIcon() . '.png" alt="User status">' . '<span class="label label-primary">' . htmlspecialchars($user) . '</span>' . ($user['client_away'] ? '<span class="label label-warning pull-right" ' . $userAwaya . '>' . $userAway . '</span>' : '<span class="label label-success pull-right">' . translate($lang["adminlist"]["status"]["online"]) . '</span>') . '</p>';
             }
 
             foreach (array_merge($onlineClients, $offlineClients) as $str)

--- a/include/adminlist.php
+++ b/include/adminlist.php
@@ -66,17 +66,20 @@ function getAdminList() {
                     $offlineClients[] = '<p><span class="label label-primary iconspacer">' . htmlspecialchars($userInfo['client_nickname']) . '</span><span class="label label-danger pull-right">' . translate($lang["adminlist"]["status"]["offline"]) . '</span></p>';
                     continue;
                 }
-                $userAwaya = '';
+
+                $userAwayTitle = '';
+
                 if(!$user["client_away_message"]) {
                     $userAway = translate($lang["adminlist"]["status"]["away"]);
-                }else{
+                } else {
                     $userAway = htmlspecialchars($user["client_away_message"]);
-                    if (strlen($userAway) > 23) {
-                        $userAwaya = 'title="' . $userAway . '"';
-                        $userAway = substr($userAway, 0, 23) . '..';
+                    if (mb_strlen($userAway) > 23) {
+                        $userAwayTitle = 'title="' . $userAway . '"';
+                        $userAway = mb_substr($userAway, 0, 23) . "...";
                     }
                 }
-                $onlineClients[] = '<p><img src="lib/ts3phpframework/images/viewer/' . $user->getIcon() . '.png" alt="User status">' . '<span class="label label-primary">' . htmlspecialchars($user) . '</span>' . ($user['client_away'] ? '<span class="label label-warning pull-right" ' . $userAwaya . '>' . $userAway . '</span>' : '<span class="label label-success pull-right">' . translate($lang["adminlist"]["status"]["online"]) . '</span>') . '</p>';
+
+                $onlineClients[] = '<p><img src="lib/ts3phpframework/images/viewer/' . $user->getIcon() . '.png" alt="User status">' . '<span class="label label-primary">' . htmlspecialchars($user) . '</span>' . ($user['client_away'] ? '<span class="label label-warning pull-right" ' . $userAwayTitle . '>' . $userAway . '</span>' : '<span class="label label-success pull-right">' . translate($lang["adminlist"]["status"]["online"]) . '</span>') . '</p>';
             }
 
             foreach (array_merge($onlineClients, $offlineClients) as $str)


### PR DESCRIPTION
Hi,
after away message was added, someone on my TS used long away message, so I decided to check your commit and in the comments, there was someone who was talking about it.. So I decided to pull request it for you. It cuts after 23characters - why? it depends on which letters are used, as you can see in the preview.
I also added "title" tag for full length of away message.

**How it looks like without cut:**
(https://github.com/Wruczek/ts-website/commit/eb98e539c6716fa3b43218eca2911e1e7e729b20#commitcomment-28565818)
![image](https://user-images.githubusercontent.com/1337953/38733456-931edb1a-3f2a-11e8-8fd7-85c2a034972e.png)

**How it looks now:**
**yolo string:** (that's why 23characters)
![image](https://user-images.githubusercontent.com/10760550/40051595-99abfff6-583b-11e8-81ca-741005cc737d.png)

**normal string**
![image](https://user-images.githubusercontent.com/10760550/40051750-2ac1db78-583c-11e8-9fc6-4f51db6b0083.png)
when it is normal string, there is still a lot of space left.. even with nick longer than 10characters.

