### PR TITLE
query_displayip containing colon won't show in URLs

### DIFF
--- a/src/private/php/Utils/TemplateUtils.php
+++ b/src/private/php/Utils/TemplateUtils.php
@@ -39,6 +39,10 @@ class TemplateUtils {
         $this->getLatte()->addFilter("translate", function ($s, ...$args) {
             return new Html(__get($s, $args));
         });
+
+        $this->getLatte()->addFilter("nocheck", function ($s, ...$args) {
+            return $s;
+        });
     }
 
     /**

--- a/src/private/templates/sidebar.latte
+++ b/src/private/templates/sidebar.latte
@@ -11,7 +11,7 @@
             <!-- The NBSP is here to preserve a space when the text gets truncated -->
             <p>
                 <span><i class="fas fa-globe fa-fw"></i>{_"STATUS_ADDRESS"}&nbsp;</span>
-                <span><a href="ts3server://{$config["query_displayip"]}">{$config["query_displayip"]}</a></span>
+                <span><a href="ts3server://{$config["query_displayip"]|nocheck}">{$config["query_displayip"]|nocheck}</a></span>
             </p>
             <p>
                 <span><i class="fas fa-power-off fa-fw"></i>{_"STATUS_CLIENTS_ONLINE"}&nbsp;</span>

--- a/src/private/templates/utils/modal-login.latte
+++ b/src/private/templates/utils/modal-login.latte
@@ -31,8 +31,8 @@
                 <!-- Not connected to the server message -->
                 <div class="not-connected text-center" style="display: none">
                     <h3>Not connected</h3>
-                    <p>Connect to <a href="ts3server://{$config["query_displayip"]}">{$config["query_displayip"]}</a> and wait ±30 seconds.<br>The website will auto-refresh.</p>
-                    <a href="ts3server://{$config["query_displayip"]}" class="btn btn-primary">
+                    <p>Connect to <a href="ts3server://{$config["query_displayip"|nocheck]}">{$config["query_displayip"]|nocheck}</a> and wait ±30 seconds.<br>The website will auto-refresh.</p>
+                    <a href="ts3server://{$config["query_displayip"]|nocheck}" class="btn btn-primary">
                         <i class="fas fa-sign-in-alt"></i>Connect
                     </a>
 


### PR DESCRIPTION
Hi there!
I recently installed the webinterface on my system, not for production!
Since I was happy about installing and testing I faced some minor issues.

My query_displayip is not only a hostname, it is a hostname with a port.
Example: `example.com:1337`

I entered the value in the database and saved. After doing that the URL in the sidebar was broken.
So I looked into the code and found the URL beginning with `ts3server://` which looked perfectly fine.
After a short debugging session I found that the templating software is doing that.

So I added a latte filter called "nocheck". I am not sure if this should be done by latte in default!
After adding the filter in PHP code I added the filter in the templates and now my URLs are working perfectly fine.