### PR TITLE
Add display swap

### DIFF
--- a/src/css/themes/dark.css
+++ b/src/css/themes/dark.css
@@ -4,7 +4,7 @@
  * (c) Wruczek 2017 - 2019
  */
 
-@import url('https://fonts.googleapis.com/css?family=Exo+2');
+@import url('https://fonts.googleapis.com/css?family=Exo+2&display=swap');
 
 :root {
     --site-background: #1e202f;


### PR DESCRIPTION
We should ensure that the text remains visible during webfont load. Further link:
https://web.dev/font-display/
This should be also done for font awesome but I didn't find a way to make it with the load of the font. Maybe we should place this in CSS.