### PR TITLE
Add Secure and SameSite Attribute

### DIFF
--- a/src/installer/dbinstall_mysql_lang.sql
+++ b/src/installer/dbinstall_mysql_lang.sql
@@ -19,8 +19,8 @@ CREATE TABLE `DBPREFIXlanguages` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `DBPREFIXlanguages` (`langid`, `englishname`, `nativename`, `langcode`, `isdefault`) VALUES
-(1, 'English', 'English', 'en', 1),
-(2, 'English (US)', 'English (US)', 'en-us', 0),
+(1, 'English', 'English', 'en-gb', 1),
+(2, 'English (US)', 'English (US)', 'en', 0),
 (3, 'Polish', 'Polski', 'pl', 0),
 (4, 'German', 'Deutsch', 'de', 0),
 (5, 'Bulgarian', 'български', 'bg', 0),

--- a/src/installer/dbinstall_mysql_lang.sql
+++ b/src/installer/dbinstall_mysql_lang.sql
@@ -19,8 +19,8 @@ CREATE TABLE `DBPREFIXlanguages` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `DBPREFIXlanguages` (`langid`, `englishname`, `nativename`, `langcode`, `isdefault`) VALUES
-(1, 'English', 'English', 'en-gb', 1),
-(2, 'English (US)', 'English (US)', 'en', 0),
+(1, 'English', 'English', 'en', 1),
+(2, 'English (US)', 'English (US)', 'en-us', 0),
 (3, 'Polish', 'Polski', 'pl', 0),
 (4, 'German', 'Deutsch', 'de', 0),
 (5, 'Bulgarian', 'български', 'bg', 0),

--- a/src/js/bans.js
+++ b/src/js/bans.js
@@ -43,6 +43,6 @@ $(document).ready(function() {
     // preserve alert dismiss with a cookie
     responsiveTip.find(".close").click(function (e) {
         e.preventDefault()
-        Cookies.set("tswebsite_banrowtip_hide", true, {expires: 365});
+        Cookies.set("tswebsite_banrowtip_hide", true, {expires: 365, secure: true, sameSite: 'Lax'});
     })
 });

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -33,7 +33,7 @@ $(function () {
     }
 
     $(".acceptcookies").click(function () {
-        Cookies.set("tswebsite_cookie_consent", true, {expires: 365});
+        Cookies.set("tswebsite_cookie_consent", true, {expires: 365, secure: true, sameSite: 'Lax'});
         $(".cookiealert").removeClass("show");
     });
     // END Cookies

--- a/src/js/viewer.js
+++ b/src/js/viewer.js
@@ -41,7 +41,7 @@ if (!Cookies.get("tswebsite_viewertip_hide")) {
     // preserve alert dismiss with a cookie
     alert.find(".close").click(function (e) {
         e.preventDefault()
-        Cookies.set("tswebsite_viewertip_hide", true, {expires: 365});
+        Cookies.set("tswebsite_viewertip_hide", true, {expires: 365, secure: true, sameSite: 'Lax'});
     })
 }
 


### PR DESCRIPTION
We should set both attributes.
Firefox already gives a warning in console that in the future it will rejected if SameSite is `none` and it hasn't the `secure` attribute.
I translated the warning in the console:
```
The cookie "tswebsite_sessionid" will soon be rejected in the future because it specifies either "None" or an invalid value for the "SameSite" attribute without using the "secure" attribute. For more information about the "SameSite" attribute, see https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite.
```

I have already tested this new cookie placements for my site and it's working quite fine.

For the SameSite attribute we can discuss.