### PR TITLE
change the exclude from dayjs

### DIFF
--- a/src/installer/dbinstall_mysql_lang.sql
+++ b/src/installer/dbinstall_mysql_lang.sql
@@ -19,8 +19,8 @@ CREATE TABLE `DBPREFIXlanguages` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `DBPREFIXlanguages` (`langid`, `englishname`, `nativename`, `langcode`, `isdefault`) VALUES
-(1, 'English', 'English', 'en', 1),
-(2, 'English (US)', 'English (US)', 'en-us', 0),
+(1, 'English', 'English', 'en-gb', 1),
+(2, 'English (US)', 'English (US)', 'en', 0),
 (3, 'Polish', 'Polski', 'pl', 0),
 (4, 'German', 'Deutsch', 'de', 0),
 (5, 'Bulgarian', 'български', 'bg', 0),

--- a/src/installer/dbinstall_mysql_lang.sql
+++ b/src/installer/dbinstall_mysql_lang.sql
@@ -19,8 +19,8 @@ CREATE TABLE `DBPREFIXlanguages` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 INSERT INTO `DBPREFIXlanguages` (`langid`, `englishname`, `nativename`, `langcode`, `isdefault`) VALUES
-(1, 'English', 'English', 'en-gb', 1),
-(2, 'English (US)', 'English (US)', 'en', 0),
+(1, 'English', 'English', 'en', 1),
+(2, 'English (US)', 'English (US)', 'en-us', 0),
 (3, 'Polish', 'Polski', 'pl', 0),
 (4, 'German', 'Deutsch', 'de', 0),
 (5, 'Bulgarian', 'български', 'bg', 0),

--- a/src/private/templates/body.latte
+++ b/src/private/templates/body.latte
@@ -190,7 +190,7 @@ $navActiveIndex = isset($navActiveIndex) ? (int) $navActiveIndex : 0;
 {$tplutils::includeScript("{cdnjs}/dayjs/1.10.4/plugin/relativeTime.min.js", "sha256-Cto+wNkJbN1edfnamCQc/qvvQ5OUDOBzibYzJrJ8ElQ=")}
 
 {var $dayjslang = __get("DAYJS_LANG", [], true)}
-{if $dayjslang !== null && $dayjslang !== "en-us"}
+{if $dayjslang !== null && $dayjslang !== "en"}
     {$tplutils::includeScript("{cdnjs}/dayjs/1.10.4/locale/$dayjslang.min.js")}
     <script>
         dayjs.locale({$dayjslang} || navigator.languages || navigator.language)

--- a/src/private/templates/body.latte
+++ b/src/private/templates/body.latte
@@ -190,8 +190,8 @@ $navActiveIndex = isset($navActiveIndex) ? (int) $navActiveIndex : 0;
 {$tplutils::includeScript("{cdnjs}/dayjs/1.10.4/plugin/relativeTime.min.js", "sha256-Cto+wNkJbN1edfnamCQc/qvvQ5OUDOBzibYzJrJ8ElQ=")}
 
 {var $dayjslang = __get("DAYJS_LANG", [], true)}
-{if $dayjslang !== null && $dayjslang !== "en"}
-    {$tplutils::includeScript("{cdnjs}/dayjs/1.10.4/locale/$dayjslang.js")}
+{if $dayjslang !== null && $dayjslang !== "en-us"}
+    {$tplutils::includeScript("{cdnjs}/dayjs/1.10.4/locale/$dayjslang.min.js")}
     <script>
         dayjs.locale({$dayjslang} || navigator.languages || navigator.language)
     </script>


### PR DESCRIPTION
Since en (https://raw.githubusercontent.com/cdnjs/cdnjs/master/ajax/libs/dayjs/1.10.4/locale/en.js) is available and en-us not (HTTP 404) we should just switch the condition.
Also we should use the  `min.js` files. The files are available for every locale file. It saves about a byte because the non minimized file has a linebreak (LF). Also some variables got replaced. It doesn't save much, but a little bit.