### PR TITLE
Convert to string before replace

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -124,7 +124,7 @@ function escapeHtml(text) {
         "'": '&#039;'
     };
 
-    return text.replace(/[&<>"']/g, function(m) { return map[m]; });
+    return text.toString().replace(/[&<>"']/g, function(m) { return map[m]; });
 }
 
 function updateTooltip(el, text) {


### PR DESCRIPTION
This fixes this error  text.replace is not a function
When somebody has this nickname 1234567890 it throws error in the server viewer.