### PR TITLE
Remove utf8_encode polyfill

### DIFF
--- a/src/installer/pages/2.php
+++ b/src/installer/pages/2.php
@@ -94,19 +94,6 @@ function checkRequirements() {
         );
     }
 
-    // Check if we are using polyfill for utf8_encode
-    {
-        $result = defined("__USING_U8ENC_POLYFILL");
-
-        showCheckResult(
-            "Function <code>utf8_encode</code> exists",
-            $result ? 1 : 0,
-            $result ?
-                "Function not found, using polyfill" :
-                "Function exists"
-        );
-    }
-
     displayCategory("Extension checks");
 
     // Extensions check

--- a/src/private/php/constants.php
+++ b/src/private/php/constants.php
@@ -9,21 +9,3 @@ define("__CONFIG_FILE",         __PRIVATE_DIR . "/dbconfig.php");
 define("__LOCALDB_FILE",        __PRIVATE_DIR . "/.sqlite.db.php");
 define("__INSTALLER_LOCK_FILE", __PRIVATE_DIR . "/INSTALLER_LOCK");
 define("__DEV_MODE",            defined("DEV_MODE") || getenv("DEV_MODE") || file_exists(__PRIVATE_DIR . "/dev_mode"));
-
-// utf8_encode polyfill - function required by TS3PHPFramework
-// Taken from: https://github.com/symfony/polyfill (MIT License)
-if (!function_exists("utf8_encode")) {
-    define("__USING_U8ENC_POLYFILL", true);
-    function utf8_encode($s) {
-        $s .= $s;
-        $len = strlen($s);
-        for ($i = $len >> 1, $j = 0; $i < $len; ++$i, ++$j) {
-            switch (true) {
-                case $s[$i] < "\x80": $s[$j] = $s[$i]; break;
-                case $s[$i] < "\xC0": $s[$j] = "\xC2"; $s[++$j] = $s[$i]; break;
-                default: $s[$j] = "\xC3"; $s[++$j] = chr(ord($s[$i]) - 64); break;
-            }
-        }
-        return substr($s, 0, $j);
-    }
-}


### PR DESCRIPTION
utf8_encode is included with PHP 7.2, which is our minimum required version.